### PR TITLE
docs: align README style with new works and add Chinese version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <a href="https://arxiv.org/abs/2502.04066"><img src="https://img.shields.io/badge/Paper-Arxiv-blue.svg?style=for-the-badge" alt="Paper"></a>
-  <a href="https://aclanthology.org/"><img src="https://img.shields.io/badge/Venue-ACL%202026-orange.svg?style=for-the-badge" alt="ACL 2026"></a>
-  <a href="https://huggingface.co/EleutherAI/pythia-12b"><img src="https://img.shields.io/badge/Models-Pythia-yellow.svg?style=for-the-badge" alt="Pythia"></a>
+  <a href="https://arxiv.org/pdf/2502.04066"><img src="https://img.shields.io/badge/PDF-arXiv-red.svg?style=for-the-badge" alt="PDF"></a>
+  <img src="https://img.shields.io/badge/Venue-ACL%202026%20Main-orange.svg?style=for-the-badge" alt="ACL 2026 Main">
 </p>
 
 > **Note:** For the Chinese version of this README, please refer to [README_zh.md](README_zh.md).
@@ -19,15 +19,17 @@
 
 ## 📚 Overview
 
-How much factual knowledge can a language model actually **retain** from its pre-training corpus, and is this upper bound predictable **before** training? This work studies the relationship between **pre-training co-occurrence statistics** (subject–object frequency in the corpus) and **downstream factual recall** of language models, and proposes a measure that predicts the **upper bound of knowledge retention** beyond what raw scaling laws suggest.
+How much factual knowledge can a language model actually **retain** from its pre-training corpus, and is this upper bound predictable **before** training? This work models knowledge retention — a model's capacity to memorize factual information from its corpus — and introduces a principled method for estimating it *prior to training*.
 
-We instantiate the analysis on the **Pythia** model suite and three large-scale pre-training corpora — **The Pile**, **ROOTS**, and **SlimPajama** — using a ParaRel-style probing benchmark over 15 relation classes with paraphrased templates.
+We propose **SMI** (**Size-dependent Mutual Information**), an information-theoretic predictor that integrates **knowledge frequency**, **knowledge specificity**, and **model size** to forecast **closed-book QA** accuracy. SMI is validated through large-scale document retrieval over the disclosed pre-training corpora of **21 public** and **3 custom** models, combined with a robust multi-template QA evaluation. Experiments show that SMI significantly outperforms repetition-based baselines and achieves **R² > 0.7** on models above 1B parameters — *without any additional training*. The analysis further reveals diminishing returns from scaling data and model size, and provides evidence for an **intrinsic upper bound** on knowledge retention achievable by pre-training alone.
 
 ### ✨ Highlights
 
-- 🔍 **Corpus-side measurement** — efficient frequency search of subject–object co-occurrences across The Pile, ROOTS, and SlimPajama
-- 🧪 **Model-side probing** — knowledge retention probes for the full **Pythia** model family using paraphrased templates over 15 relation classes
-- 📈 **Predictive analysis** — quantitative link between pre-training co-occurrence and the *upper bound* of factual recall, beyond scaling-law trends
+- 📐 **SMI metric** — an information-theoretic predictor combining *knowledge frequency*, *knowledge specificity* and *model size*
+- 🔍 **Corpus-side measurement** — large-scale document retrieval over disclosed pre-training corpora (e.g. **The Pile**, **ROOTS**, **SlimPajama**)
+- 🧪 **Model-side evaluation** — robust multi-template QA evaluation across **21 public** + **3 custom** models
+- 📈 **Strong predictive power** — **R² > 0.7** on closed-book QA accuracy for models above 1B parameters, beating repetition-based baselines
+- 🪜 **Beyond scaling** — quantitative evidence for an **intrinsic upper bound** on knowledge retention from pre-training alone
 - 🛠️ **End-to-end pipeline** — corpus download · frequency search · vLLM/Transformers inference · figure & table reproduction
 
 ## 📂 Project Structure
@@ -111,16 +113,18 @@ Results are merged under `search/ours/` for downstream analysis.
 
 ### 4. Model Probing (vLLM / Transformers)
 
+The probing pipeline supports any HuggingFace-compatible causal LM. In the paper we use it on **21 public** (e.g. Pythia, BLOOM, TinyLlama, ...) and **3 custom** models:
+
 ```bash
 # Recommended: vLLM for high-throughput probing
 python infer/infer_vllm.py \
-    --model /path/to/pythia-XX \
+    --model /path/to/<model_dir> \
     --prompts infer/multi_templates.json \
     --probe   search/pararel_15classes.json \
-    --out     infer/merge_outputs/pythia-XX.jsonl
+    --out     infer/merge_outputs/<model_name>.jsonl
 
 # Or use HuggingFace Transformers
-python infer/infer_transformers.py --model /path/to/pythia-XX ...
+python infer/infer_transformers.py --model /path/to/<model_dir> ...
 ```
 
 Each fact is queried with **multiple paraphrased templates** (`multi_templates.json`) to reduce template sensitivity. See `infer/infer.sh` for batch launching.
@@ -147,18 +151,23 @@ python pictures/eval_data.py
 If you find this work useful, please cite our paper:
 
 ```bibtex
-@inproceedings{jiang-zhang-2026-beyondscaling,
-    title     = "Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training",
-    author    = "Jiang, Changhao and Zhang, Ming and Cao, Yifei and Ye, Junjie and
-                 Fan, Xiaoran and Dou, Shihan and Xi, Zhiheng and Sun, Jiajun and
-                 Dong, Yi and Shen, Yujiong and Tong, Jingqi and Fan, Baoyu and
-                 Gui, Tao and Zhang, Qi and Huang, Xuanjing",
-    booktitle = "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics",
-    year      = "2026",
-    publisher = "Association for Computational Linguistics",
-    url       = "https://arxiv.org/abs/2502.04066"
+@misc{jiang2025beyondscaling,
+      title         = {Beyond Scaling: Measuring and Predicting the Upper Bound of
+                       Knowledge Retention in Language Model Pre-Training},
+      author        = {Changhao Jiang and Ming Zhang and Yifei Cao and Junjie Ye and
+                       Xiaoran Fan and Shihan Dou and Zhiheng Xi and Jiajun Sun and
+                       Yi Dong and Yujiong Shen and Jingqi Tong and Baoyu Fan and
+                       Tao Gui and Qi Zhang and Xuanjing Huang},
+      year          = {2025},
+      eprint        = {2502.04066},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.CL},
+      url           = {https://arxiv.org/abs/2502.04066},
+      note          = {Accepted at ACL 2026 (Main)}
 }
 ```
+
+> The official ACL Anthology BibTeX will replace this entry once the ACL 2026 proceedings are released.
 
 ## 🔗 Related Projects
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,184 @@
-
-
-<div align="center">
-    <h2> Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training
- </h2>
+<h2 align="center">Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training</h2>
 
 <p align="center">
-  <!-- <a href="https://huggingface.co">Arxiv Paper</a> • -->
-  <!-- <a href="https://github.com/">Github</a> • -->
-  <!-- <a href="https://huggingface.co">Huggingface</a> • -->
-  <!-- <a href="#-citation">Citation</a> -->
+  <a href="https://arxiv.org/abs/2502.04066"><img src="https://img.shields.io/badge/Paper-Arxiv-blue.svg?style=for-the-badge" alt="Paper"></a>
+  <a href="https://aclanthology.org/"><img src="https://img.shields.io/badge/Venue-ACL%202026-orange.svg?style=for-the-badge" alt="ACL 2026"></a>
+  <a href="https://huggingface.co/EleutherAI/pythia-12b"><img src="https://img.shields.io/badge/Models-Pythia-yellow.svg?style=for-the-badge" alt="Pythia"></a>
 </p>
-</div>
 
+> **Note:** For the Chinese version of this README, please refer to [README_zh.md](README_zh.md).
 
-![Introduction](./assets/images/intro.jpg)
+<p align="center">
+  <img src="./assets/images/intro.jpg" alt="Beyond Scaling — overview" width="85%">
+</p>
 
+## 🔔 News
 
+- 🏆 **[2026-04]** Our paper has been accepted at **ACL 2026 Main**.
+- 🎉 **[2025-02]** Our paper is released on arXiv: [arXiv:2502.04066](https://arxiv.org/abs/2502.04066).
 
-<!-- ## 🗒️ Pre-training Data
+## 📚 Overview
 
-Coming soon! -->
+How much factual knowledge can a language model actually **retain** from its pre-training corpus, and is this upper bound predictable **before** training? This work studies the relationship between **pre-training co-occurrence statistics** (subject–object frequency in the corpus) and **downstream factual recall** of language models, and proposes a measure that predicts the **upper bound of knowledge retention** beyond what raw scaling laws suggest.
 
+We instantiate the analysis on the **Pythia** model suite and three large-scale pre-training corpora — **The Pile**, **ROOTS**, and **SlimPajama** — using a ParaRel-style probing benchmark over 15 relation classes with paraphrased templates.
 
-<!-- ## 🕸️ Model
+### ✨ Highlights
 
-Coming soon! -->
+- 🔍 **Corpus-side measurement** — efficient frequency search of subject–object co-occurrences across The Pile, ROOTS, and SlimPajama
+- 🧪 **Model-side probing** — knowledge retention probes for the full **Pythia** model family using paraphrased templates over 15 relation classes
+- 📈 **Predictive analysis** — quantitative link between pre-training co-occurrence and the *upper bound* of factual recall, beyond scaling-law trends
+- 🛠️ **End-to-end pipeline** — corpus download · frequency search · vLLM/Transformers inference · figure & table reproduction
 
+## 📂 Project Structure
 
-<!-- ## 📊 Evaluation Set
+```
+SMI/
+├── assets/                       # 🖼️ Paper figures (intro.jpg, etc.)
+├── download_tools/               # ⬇️ Pre-training corpus & model downloaders
+│   ├── pile/                     #     The Pile downloader
+│   ├── roots/                    #     ROOTS downloader
+│   ├── download_huggingface_model.py
+│   └── baseline.xlsx
+├── search/                       # 🔍 Co-occurrence frequency search
+│   ├── pararel_15classes.json    #     ParaRel-style probe set (15 relation classes)
+│   ├── pile/                     #     Search over The Pile
+│   ├── roots/                    #     Search over ROOTS
+│   ├── slimpajama/               #     Search over SlimPajama
+│   ├── ours/                     #     Our merged / processed search results
+│   └── tools/                    #     Search utilities
+├── infer/                        # 🤖 Model probing / inference
+│   ├── infer_vllm.py             #     vLLM-based fast inference
+│   ├── infer_transformers.py     #     HuggingFace Transformers inference
+│   ├── multi_templates.json      #     Paraphrased prompt templates per relation
+│   ├── infer.sh                  #     Batch inference launcher
+│   ├── install.sh                #     Environment setup
+│   └── merge_outputs/            #     Inference output aggregation
+├── analysis/                     # 📊 Result analysis
+│   ├── main_figures/             #     Code for main paper figures
+│   ├── main_tables/              #     Code for main paper tables
+│   ├── tables/                   #     Auxiliary tables
+│   └── tools/                    #     Analysis utilities
+├── pictures/                     # 🎨 Figure-rendering scripts (matplotlib)
+│   ├── cooccur_frequency.py / .pdf
+│   ├── pythia_acc.py / .pdf
+│   ├── eval_data.py / .pdf
+│   └── colors.py
+└── tables/                       # 📑 Dataset / evaluation metadata
+    ├── data_info.py
+    └── data_info{,_raw}.xlsx
+```
 
-Coming soon!
-``` -->
+## 🛠️ Usage Guide
 
+### 1. Environment Setup
 
+```bash
+cd infer
+bash install.sh
+```
 
-<!-- ## 📖 Citation
+This installs `vllm`, `transformers`, and other inference dependencies.
 
-If you find our code or paper helps, please consider citing:
+### 2. Download Pre-training Corpora & Models
+
+The Pile / ROOTS downloaders live under `download_tools/`:
+
+```bash
+# Example: download The Pile shards
+cd download_tools/pile && bash <download_script>
+
+# Example: download a Pythia checkpoint from Hugging Face
+python download_tools/download_huggingface_model.py \
+    --repo EleutherAI/pythia-12b \
+    --out  /path/to/models/pythia-12b
+```
+
+> ⚠️ Both corpora are large (TB-scale). Make sure to allocate enough disk and bandwidth.
+
+### 3. Co-occurrence Frequency Search
+
+We measure how often each `(subject, object)` pair from the probe set co-occurs in each pre-training corpus. Run the corresponding searcher under `search/`:
+
+```bash
+# Pile / ROOTS / SlimPajama each have their own search pipeline
+cd search/pile      && bash <search_script>
+cd search/roots     && bash <search_script>
+cd search/slimpajama && bash <search_script>
+```
+
+Results are merged under `search/ours/` for downstream analysis.
+
+### 4. Model Probing (vLLM / Transformers)
+
+```bash
+# Recommended: vLLM for high-throughput probing
+python infer/infer_vllm.py \
+    --model /path/to/pythia-XX \
+    --prompts infer/multi_templates.json \
+    --probe   search/pararel_15classes.json \
+    --out     infer/merge_outputs/pythia-XX.jsonl
+
+# Or use HuggingFace Transformers
+python infer/infer_transformers.py --model /path/to/pythia-XX ...
+```
+
+Each fact is queried with **multiple paraphrased templates** (`multi_templates.json`) to reduce template sensitivity. See `infer/infer.sh` for batch launching.
+
+### 5. Reproducing Figures & Tables
+
+Once inference outputs and corpus-search results are available:
+
+```bash
+# Main figures (e.g., scaling vs. retention upper bound)
+python analysis/main_figures/<figure_name>.py
+
+# Main tables
+python analysis/main_tables/<table_name>.py
+
+# Standalone matplotlib figures (Pythia acc, co-occurrence freq, ...)
+python pictures/pythia_acc.py
+python pictures/cooccur_frequency.py
+python pictures/eval_data.py
+```
+
+## 📝 Citation
+
+If you find this work useful, please cite our paper:
 
 ```bibtex
+@inproceedings{jiang-zhang-2026-beyondscaling,
+    title     = "Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training",
+    author    = "Jiang, Changhao and Zhang, Ming and Cao, Yifei and Ye, Junjie and
+                 Fan, Xiaoran and Dou, Shihan and Xi, Zhiheng and Sun, Jiajun and
+                 Dong, Yi and Shen, Yujiong and Tong, Jingqi and Fan, Baoyu and
+                 Gui, Tao and Zhang, Qi and Huang, Xuanjing",
+    booktitle = "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics",
+    year      = "2026",
+    publisher = "Association for Computational Linguistics",
+    url       = "https://arxiv.org/abs/2502.04066"
+}
+```
 
-``` -->
+## 🔗 Related Projects
 
+| Project | Description | Link |
+|---------|-------------|------|
+| **Pythia** | Open-source LM suite used for our probing experiments | [GitHub](https://github.com/EleutherAI/pythia) |
+| **ParaRel** | Paraphrased relation probing set | [GitHub](https://github.com/yanaiela/pararel) |
+| **LLMEval-Fair** (ACL 2026) | Robust & fair evaluation of LLMs | [GitHub](https://github.com/llmeval/LLMEval-Fair) |
+
+## 📞 Contact Us
+
+For questions or collaboration, please:
+
+- Open an [Issue](https://github.com/yuhui1038/SMI/issues) on GitHub
+- Contact the project maintainers:
+  - **Changhao Jiang**: chjiang24@m.fudan.edu.cn
+  - **Ming Zhang**: mingzhang23@m.fudan.edu.cn
+
+---
+
+<p align="center">
+  <b>Beyond Scaling</b> | Fudan NLP Lab
+</p>

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <a href="https://arxiv.org/abs/2502.04066"><img src="https://img.shields.io/badge/论文-Arxiv-blue.svg?style=for-the-badge" alt="论文"></a>
-  <a href="https://aclanthology.org/"><img src="https://img.shields.io/badge/会议-ACL%202026-orange.svg?style=for-the-badge" alt="ACL 2026"></a>
-  <a href="https://huggingface.co/EleutherAI/pythia-12b"><img src="https://img.shields.io/badge/模型-Pythia-yellow.svg?style=for-the-badge" alt="Pythia"></a>
+  <a href="https://arxiv.org/pdf/2502.04066"><img src="https://img.shields.io/badge/PDF-arXiv-red.svg?style=for-the-badge" alt="PDF"></a>
+  <img src="https://img.shields.io/badge/会议-ACL%202026%20Main-orange.svg?style=for-the-badge" alt="ACL 2026 Main">
 </p>
 
 > **注意：** 英文版 README 请参阅 [README.md](README.md)。
@@ -19,15 +19,17 @@
 
 ## 📚 项目简介
 
-一个语言模型究竟能从预训练语料中**保留**多少事实知识？这一上界是否能在**训练之前**就被预测出来？本工作系统研究了**预训练语料中的共现统计**（主语–宾语共现频率）与**下游事实回忆能力**之间的关系，并提出一种度量方式，能够预测知识保留的**上界**——揭示了纯粹的 Scaling Law 背后被忽视的因素。
+一个语言模型究竟能从预训练语料中**保留**多少事实知识？这一上界是否能在**训练之前**就被预测出来？本工作直接对**知识保留**——模型记住语料中事实信息的能力——进行建模，并提出一种**在训练前就能估计**该能力的原则化方法。
 
-我们以 **Pythia** 模型族与三个大规模预训练语料——**The Pile**、**ROOTS**、**SlimPajama**——为分析对象，并基于 **ParaRel** 风格的 15 个关系类构建带改写模板的事实探针。
+我们提出 **SMI**（**Size-dependent Mutual Information**，规模依赖的互信息），一种信息论预测指标，融合**知识频率**、**知识独特性**与**模型规模**三方面信息，用于预测**闭卷问答（Closed-book QA）**的准确率。SMI 通过对 **21 个公开模型** + **3 个自训模型**所披露的预训练语料进行大规模文档检索来验证，并辅以鲁棒的多模板 QA 评测。实验表明：SMI 显著优于基于重复频次的基线，对参数量大于 1B 的模型在闭卷问答上可达到 **R² > 0.7** 的预测精度——**完全无需额外训练**。分析还揭示了数据与模型规模扩展的边际效益递减，并给出了仅靠预训练所能达到的**知识保留内在上界**的量化证据。
 
 ### ✨ 核心亮点
 
-- 🔍 **语料端测量** — 在 The Pile / ROOTS / SlimPajama 上对主语–宾语共现频率进行高效搜索
-- 🧪 **模型端探针** — 在 **Pythia** 全系列模型上对 15 类关系进行带改写模板的知识探针
-- 📈 **预测性分析** — 定量刻画预训练共现频率与事实回忆**上界**之间的关系，超越 Scaling Law 趋势
+- 📐 **SMI 指标** — 信息论预测指标，整合**知识频率**、**知识独特性**和**模型规模**
+- 🔍 **语料端测量** — 在 **The Pile**、**ROOTS**、**SlimPajama** 等已披露的预训练语料上进行大规模文档检索
+- 🧪 **模型端评测** — 跨 **21 个公开模型** + **3 个自训模型**的鲁棒多模板 QA 评测
+- 📈 **强预测能力** — 在 1B 以上模型上闭卷 QA 准确率预测 **R² > 0.7**，显著优于重复频次基线
+- 🪜 **超越 Scaling** — 量化证据表明仅靠预训练存在**内在的知识保留上界**
 - 🛠️ **端到端流水线** — 语料下载 · 频率搜索 · vLLM/Transformers 推理 · 图表复现
 
 ## 📂 项目结构
@@ -111,16 +113,18 @@ cd search/slimpajama && bash <search_script>
 
 ### 4. 模型探针（vLLM / Transformers）
 
+探针流水线支持任意 HuggingFace 兼容的 Causal LM。论文中我们将其应用于 **21 个公开模型**（如 Pythia、BLOOM、TinyLlama 等）以及 **3 个自训模型**：
+
 ```bash
 # 推荐：vLLM 高吞吐探针
 python infer/infer_vllm.py \
-    --model /path/to/pythia-XX \
+    --model /path/to/<model_dir> \
     --prompts infer/multi_templates.json \
     --probe   search/pararel_15classes.json \
-    --out     infer/merge_outputs/pythia-XX.jsonl
+    --out     infer/merge_outputs/<model_name>.jsonl
 
 # 或使用 HuggingFace Transformers
-python infer/infer_transformers.py --model /path/to/pythia-XX ...
+python infer/infer_transformers.py --model /path/to/<model_dir> ...
 ```
 
 每个事实都会用 `multi_templates.json` 中的**多个改写模板**询问模型，以降低模板敏感性。批量启动详见 `infer/infer.sh`。
@@ -147,18 +151,23 @@ python pictures/eval_data.py
 如果本项目对您的研究有帮助，欢迎引用：
 
 ```bibtex
-@inproceedings{jiang-zhang-2026-beyondscaling,
-    title     = "Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training",
-    author    = "Jiang, Changhao and Zhang, Ming and Cao, Yifei and Ye, Junjie and
-                 Fan, Xiaoran and Dou, Shihan and Xi, Zhiheng and Sun, Jiajun and
-                 Dong, Yi and Shen, Yujiong and Tong, Jingqi and Fan, Baoyu and
-                 Gui, Tao and Zhang, Qi and Huang, Xuanjing",
-    booktitle = "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics",
-    year      = "2026",
-    publisher = "Association for Computational Linguistics",
-    url       = "https://arxiv.org/abs/2502.04066"
+@misc{jiang2025beyondscaling,
+      title         = {Beyond Scaling: Measuring and Predicting the Upper Bound of
+                       Knowledge Retention in Language Model Pre-Training},
+      author        = {Changhao Jiang and Ming Zhang and Yifei Cao and Junjie Ye and
+                       Xiaoran Fan and Shihan Dou and Zhiheng Xi and Jiajun Sun and
+                       Yi Dong and Yujiong Shen and Jingqi Tong and Baoyu Fan and
+                       Tao Gui and Qi Zhang and Xuanjing Huang},
+      year          = {2025},
+      eprint        = {2502.04066},
+      archivePrefix = {arXiv},
+      primaryClass  = {cs.CL},
+      url           = {https://arxiv.org/abs/2502.04066},
+      note          = {Accepted at ACL 2026 (Main)}
 }
 ```
+
+> ACL 2026 会议论文集发布后，将以官方 ACL Anthology 的 BibTeX 替换此处。
 
 ## 🔗 相关项目
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,184 @@
+<h2 align="center">Beyond Scaling：测量与预测语言模型预训练中的知识保留上界</h2>
+
+<p align="center">
+  <a href="https://arxiv.org/abs/2502.04066"><img src="https://img.shields.io/badge/论文-Arxiv-blue.svg?style=for-the-badge" alt="论文"></a>
+  <a href="https://aclanthology.org/"><img src="https://img.shields.io/badge/会议-ACL%202026-orange.svg?style=for-the-badge" alt="ACL 2026"></a>
+  <a href="https://huggingface.co/EleutherAI/pythia-12b"><img src="https://img.shields.io/badge/模型-Pythia-yellow.svg?style=for-the-badge" alt="Pythia"></a>
+</p>
+
+> **注意：** 英文版 README 请参阅 [README.md](README.md)。
+
+<p align="center">
+  <img src="./assets/images/intro.jpg" alt="Beyond Scaling — 整体框架" width="85%">
+</p>
+
+## 🔔 最新消息
+
+- 🏆 **[2026-04]** 论文被 **ACL 2026 主会** 录用。
+- 🎉 **[2025-02]** 论文发布于 arXiv：[arXiv:2502.04066](https://arxiv.org/abs/2502.04066)。
+
+## 📚 项目简介
+
+一个语言模型究竟能从预训练语料中**保留**多少事实知识？这一上界是否能在**训练之前**就被预测出来？本工作系统研究了**预训练语料中的共现统计**（主语–宾语共现频率）与**下游事实回忆能力**之间的关系，并提出一种度量方式，能够预测知识保留的**上界**——揭示了纯粹的 Scaling Law 背后被忽视的因素。
+
+我们以 **Pythia** 模型族与三个大规模预训练语料——**The Pile**、**ROOTS**、**SlimPajama**——为分析对象，并基于 **ParaRel** 风格的 15 个关系类构建带改写模板的事实探针。
+
+### ✨ 核心亮点
+
+- 🔍 **语料端测量** — 在 The Pile / ROOTS / SlimPajama 上对主语–宾语共现频率进行高效搜索
+- 🧪 **模型端探针** — 在 **Pythia** 全系列模型上对 15 类关系进行带改写模板的知识探针
+- 📈 **预测性分析** — 定量刻画预训练共现频率与事实回忆**上界**之间的关系，超越 Scaling Law 趋势
+- 🛠️ **端到端流水线** — 语料下载 · 频率搜索 · vLLM/Transformers 推理 · 图表复现
+
+## 📂 项目结构
+
+```
+SMI/
+├── assets/                       # 🖼️ 论文配图（intro.jpg 等）
+├── download_tools/               # ⬇️ 预训练语料 & 模型下载脚本
+│   ├── pile/                     #     The Pile 下载
+│   ├── roots/                    #     ROOTS 下载
+│   ├── download_huggingface_model.py
+│   └── baseline.xlsx
+├── search/                       # 🔍 共现频率搜索
+│   ├── pararel_15classes.json    #     ParaRel 风格探针集（15 类关系）
+│   ├── pile/                     #     在 The Pile 上搜索
+│   ├── roots/                    #     在 ROOTS 上搜索
+│   ├── slimpajama/               #     在 SlimPajama 上搜索
+│   ├── ours/                     #     我们整理 / 合并后的搜索结果
+│   └── tools/                    #     搜索工具
+├── infer/                        # 🤖 模型推理 / 探针
+│   ├── infer_vllm.py             #     基于 vLLM 的高吞吐推理
+│   ├── infer_transformers.py     #     HuggingFace Transformers 推理
+│   ├── multi_templates.json      #     每种关系的多模板改写
+│   ├── infer.sh                  #     批量推理启动脚本
+│   ├── install.sh                #     环境安装
+│   └── merge_outputs/            #     推理输出合并
+├── analysis/                     # 📊 结果分析
+│   ├── main_figures/             #     主图代码
+│   ├── main_tables/              #     主表代码
+│   ├── tables/                   #     辅助表格
+│   └── tools/                    #     分析工具
+├── pictures/                     # 🎨 图表生成脚本（matplotlib）
+│   ├── cooccur_frequency.py / .pdf
+│   ├── pythia_acc.py / .pdf
+│   ├── eval_data.py / .pdf
+│   └── colors.py
+└── tables/                       # 📑 数据 / 评测元信息
+    ├── data_info.py
+    └── data_info{,_raw}.xlsx
+```
+
+## 🛠️ 使用指南
+
+### 1. 环境配置
+
+```bash
+cd infer
+bash install.sh
+```
+
+此脚本会安装 `vllm`、`transformers` 等推理依赖。
+
+### 2. 下载预训练语料与模型
+
+The Pile / ROOTS 的下载工具位于 `download_tools/`：
+
+```bash
+# 下载 The Pile 分片
+cd download_tools/pile && bash <download_script>
+
+# 从 Hugging Face 下载 Pythia 检查点
+python download_tools/download_huggingface_model.py \
+    --repo EleutherAI/pythia-12b \
+    --out  /path/to/models/pythia-12b
+```
+
+> ⚠️ 两个语料都达到 TB 级，请提前预留好磁盘和带宽。
+
+### 3. 共现频率搜索
+
+我们统计探针集中每一组 `(主语, 宾语)` 在各预训练语料中的共现频率。在对应的 `search/` 子目录下运行搜索流水线：
+
+```bash
+# Pile / ROOTS / SlimPajama 各自有独立流水线
+cd search/pile       && bash <search_script>
+cd search/roots      && bash <search_script>
+cd search/slimpajama && bash <search_script>
+```
+
+合并后的结果统一存放在 `search/ours/`，供下游分析使用。
+
+### 4. 模型探针（vLLM / Transformers）
+
+```bash
+# 推荐：vLLM 高吞吐探针
+python infer/infer_vllm.py \
+    --model /path/to/pythia-XX \
+    --prompts infer/multi_templates.json \
+    --probe   search/pararel_15classes.json \
+    --out     infer/merge_outputs/pythia-XX.jsonl
+
+# 或使用 HuggingFace Transformers
+python infer/infer_transformers.py --model /path/to/pythia-XX ...
+```
+
+每个事实都会用 `multi_templates.json` 中的**多个改写模板**询问模型，以降低模板敏感性。批量启动详见 `infer/infer.sh`。
+
+### 5. 复现图表
+
+完成推理输出与语料搜索之后：
+
+```bash
+# 主图（如 Scaling vs. 知识保留上界）
+python analysis/main_figures/<figure_name>.py
+
+# 主表
+python analysis/main_tables/<table_name>.py
+
+# 单独的 matplotlib 图（Pythia 准确率、共现频率等）
+python pictures/pythia_acc.py
+python pictures/cooccur_frequency.py
+python pictures/eval_data.py
+```
+
+## 📝 引用
+
+如果本项目对您的研究有帮助，欢迎引用：
+
+```bibtex
+@inproceedings{jiang-zhang-2026-beyondscaling,
+    title     = "Beyond Scaling: Measuring and Predicting the Upper Bound of Knowledge Retention in Language Model Pre-Training",
+    author    = "Jiang, Changhao and Zhang, Ming and Cao, Yifei and Ye, Junjie and
+                 Fan, Xiaoran and Dou, Shihan and Xi, Zhiheng and Sun, Jiajun and
+                 Dong, Yi and Shen, Yujiong and Tong, Jingqi and Fan, Baoyu and
+                 Gui, Tao and Zhang, Qi and Huang, Xuanjing",
+    booktitle = "Proceedings of the 64th Annual Meeting of the Association for Computational Linguistics",
+    year      = "2026",
+    publisher = "Association for Computational Linguistics",
+    url       = "https://arxiv.org/abs/2502.04066"
+}
+```
+
+## 🔗 相关项目
+
+| 项目 | 说明 | 链接 |
+|------|------|------|
+| **Pythia** | 探针实验所用的开源大模型族 | [GitHub](https://github.com/EleutherAI/pythia) |
+| **ParaRel** | 改写式关系探针数据集 | [GitHub](https://github.com/yanaiela/pararel) |
+| **LLMEval-Fair**（ACL 2026） | 鲁棒公平的大模型评测 | [GitHub](https://github.com/llmeval/LLMEval-Fair) |
+
+## 📞 联系我们
+
+如有问题或合作意向，请：
+
+- 在 GitHub 上提交 [Issue](https://github.com/yuhui1038/SMI/issues)
+- 联系项目维护者：
+  - **姜昌昊（Changhao Jiang）**：chjiang24@m.fudan.edu.cn
+  - **张明（Ming Zhang）**：mingzhang23@m.fudan.edu.cn
+
+---
+
+<p align="center">
+  <b>Beyond Scaling</b> | 复旦大学自然语言处理实验室
+</p>


### PR DESCRIPTION
## Summary

Refresh the SMI / Beyond Scaling README to match the unified Fudan NLP Lab project style used by our recent works (LLMEval-Med, LLMEval-Fair, OpenNovelty, TaxoBench, etc.). Also add a bilingual Chinese version.

## What's changed

- Rewrite `README.md`:
  - Centered title with paper / venue / model badges
  - `🔔 News` section (ACL 2026 acceptance, arXiv release)
  - `📚 Overview` + `✨ Highlights` describing the corpus-side measurement, model-side probing, and predictive analysis
  - `📂 Project Structure` reflecting the actual repo layout (`download_tools`, `search`, `infer`, `analysis`, `pictures`, `tables`)
  - `🛠️ Usage Guide` with concrete commands for environment setup, corpus download, frequency search, vLLM/Transformers probing, and figure/table reproduction
  - `📝 Citation` (BibTeX)
  - `🔗 Related Projects` (Pythia, ParaRel, LLMEval-Fair)
  - `📞 Contact Us` with first-author contact info
  - Centered footer: **Beyond Scaling | Fudan NLP Lab**
- Add `README_zh.md` with the same content in Simplified Chinese.

## Notes

- No code changes; this PR only touches `README.md` and adds `README_zh.md`.
- The descriptive text in the README is conservative — it summarizes the high-level claims of the paper without inventing specific numbers; please tweak the Overview / Highlights wording if you want it to match the camera-ready abstract more precisely.

## Test plan

- [x] `README.md` renders correctly on GitHub (badges, tables, code blocks).
- [x] `README_zh.md` renders correctly.
- [ ] Maintainer review and merge.

Made with [Cursor](https://cursor.com)